### PR TITLE
Adjsted to match test sintax for sh.

### DIFF
--- a/packageOCSAgent.sh
+++ b/packageOCSAgent.sh
@@ -25,7 +25,7 @@ INSTALL_PACKAGE=0
 ERROR_PACKAGE=0
 [ $(which gcc) ] && [ $(which make) ] && [ $(which rsync) ] && [ $(which g++) ] || INSTALL_PACKAGE=1
 
-if [ $INSTALL_PACKAGE == 1 ];then
+if [ $INSTALL_PACKAGE = 1 ];then
 	if [ -f /etc/redhat-release ];then
 		yum install -y gcc make rsync gcc-c++ || ERROR_PACKAGE=1
 	elif [ -f /etc/debian_version ];then


### PR DESCRIPTION
## Status
**READY**

## Description
In sh shell the test sintax use only one "=" and not two "==", like bash sintax.

## Related Issues
This correct issue 9: https://github.com/OCSInventory-NG/Packager-for-Unix/issues/9

## Todos
- [] Tests

## Test environment
Tested on Debian 8 - jessie.